### PR TITLE
change layout of results

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,13 +3,19 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Speechly Browser Client Example</title>
+    <title>Speechly Home Automation Demo</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <h1>Speechly Browser Client Example</h1>
-    <p>Start by clicking Connect below.</p>
-    <p>Check out our Spoken Language Understanding API for developers at <a href="https://www.speechly.com/">speechly.com</a></p>
+    <h1>Speechly Home Automation Demo</h1>
+    <p>Check out our spoken language understanding API for developers at <a href="https://speechly.com" rel="noreferrer noopener" target="_blank">https://speechly.com</a></p>
+    <p>Start by clicking the "Connect" button and then try saying the following phrases while holding down the "Record" button:</p>
+    <ul>
+      <li><em>"Turn on the lights in the kitchen"</em></li>
+      <li><em>"Switch off the television in the bedroom"</em></li>
+      <li><em>"Put on the lights in the living room"</em></li>
+      <li><em>"Set off the radio in the living room"</em></li>
+    </ul>
 
     <div>
       <h3 id="status">Disconnected</h3>
@@ -17,8 +23,6 @@
       <button id="record" disabled="true">Record</button>
       <p id="final"></p>
     </div>
-
- 
 
     <div id="results" style="width:100%">
       <div id="transcript" style="width: 33%; float:left" >

--- a/public/index.html
+++ b/public/index.html
@@ -3,19 +3,13 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Speechly Home Automation Demo</title>
+    <title>Speechly Browser Client Example</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <h1>Speechly Demo</h1>
-    <p>Check out our spoken language understanding API for developers at <a href="https://speechly.com">speechly.com</a></p>
-    <p>Try saying the following phrases:</p>
-    <ul>
-      <li><em>"Turn on the lights in the kitchen"</em></li>
-      <li><em>"Switch off the television in the bedroom"</em></li>
-      <li><em>"Put on the lights in the living room"</em></li>
-      <li><em>"Set off the radio in the living room"</em></li>
-    </ul>
+    <h1>Speechly Browser Client Example</h1>
+    <p>Start by clicking Connect below.</p>
+    <p>Check out our Spoken Language Understanding API for developers at <a href="https://www.speechly.com/">speechly.com</a></p>
 
     <div>
       <h3 id="status">Disconnected</h3>
@@ -24,25 +18,26 @@
       <p id="final"></p>
     </div>
 
-    <div id="transcript">
-      <h3>Transcript</h3>
-      <p id="transcript-words"></p>
+ 
 
-      <h3>Words</h3>
-      <ul id="transcript-list"></ol>
+    <div id="results" style="width:100%">
+      <div id="transcript" style="width: 33%; float:left" >
+        <h3>Transcript</h3>
+        <p id="transcript-words"></p>
+
+        <h3>Words</h3>
+        <ul id="transcript-list"></ul>
+      </div>
+      <div id="intent" style="width: 33%; float:left">
+        <h3>Intent</h3>
+        <p id="intent-value"></p>
+      </div>
+      <div id="entities" style="width:33%; float:left">
+        <h3>Entities</h3>
+        <ul id="entities-list"></ol>
+      </div>
     </div>
-
-    <div id="entities">
-      <h3>Entities</h3>
-      <ul id="entities-list"></ol>
-    </div>
-
-    <div id="intent">
-      <h3>Intent</h3>
-      <p id="intent-value"></p>
-    </div>
-
-    <div id="log">
+    <div id="log" style="clear: both">
       <h3>Log</h3>
       <table>
         <thead>


### PR DESCRIPTION
Shows more relevant content on one page with no scrolling with minimal styling. Also removes instructions "Turn off kitchen lights" that are not relevant if users are using their own app ids, like they should.

<img width="1371" alt="Näyttökuva 2020-5-5 kello 8 36 52" src="https://user-images.githubusercontent.com/2462500/81037484-93e48400-8eab-11ea-90dc-0b7816477b3a.png">
